### PR TITLE
bump ts version due to security failure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -90,7 +90,7 @@
         "sass": "^1.77.6",
         "supertest": "^7.0.0",
         "ts-jest": "^29.1.1",
-        "typescript": "^5.5"
+        "typescript": "^5.5.4"
       },
       "engines": {
         "node": "^20",
@@ -12256,9 +12256,9 @@
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
     },
     "node_modules/typescript": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.3.tgz",
-      "integrity": "sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==",
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -173,6 +173,6 @@
     "sass": "^1.77.6",
     "supertest": "^7.0.0",
     "ts-jest": "^29.1.1",
-    "typescript": "^5.5"
+    "typescript": "^5.5.4"
   }
 }


### PR DESCRIPTION
```
Package     Current  Wanted  Latest  Location                 Depended by
typescript    5.5.3   5.5.4   5.5.4  node_modules/typescript  jest-html-reporter
typescript    5.5.3   5.5.4   5.5.4  node_modules/typescript  ts-jest
typescript    5.5.3   5.5.4   5.5.4  node_modules/typescript  app
typescript    5.5.3   5.5.4   5.5.4  node_modules/typescript  ts-api-utils

Exited with code exit status 1
